### PR TITLE
Adding support for Error:ErrorCode and ScanningFinished messages

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -4,7 +4,7 @@ import * as Messages from "../src/core/messages";
 
 let devices: Device[] = [];
 let client = new ButtplugClient("Example Typescript Client");
-client.Connect("ws://192.168.123.2:12345/buttplug").then(
+client.Connect("wss://localhost:12345/buttplug").then(
     function (result) {
         console.log(result); // "Stuff worked!"
         return client.StartScanning();

--- a/example/index.ts
+++ b/example/index.ts
@@ -27,7 +27,11 @@ client.Connect("ws://192.168.123.2:12345/buttplug").then(
         console.log(err); // Error: "It broke"
       }
   );
-
+  
+client.on("deviceadded", function() {
+        devices = client.getDevices();
+});
+  
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -10,6 +10,7 @@ export class ButtplugClient extends EventEmitter {
   private _counter: number = 1;
   private _waitingMsgs: Map<number, (val: Messages.ButtplugMessage) => void> = new Map();
   private _clientName: string;
+  private _pingTimer;
 
   constructor(aClientName: string) {
     super();
@@ -25,8 +26,12 @@ export class ButtplugClient extends EventEmitter {
       let msg = await this.SendMessage(new Messages.RequestServerInfo(this._clientName));
       switch (msg.getType()) {
         case 'ServerInfo':
-          // TODO: Actually deal with ping timing, maybe store server name, do
-          // something with message template version?
+          // TODO: maybe store server name, do something with message template version?
+          let ping = (msg as Messages.ServerInfo).MaxPingTime;
+          if (ping > 0) {
+            this._pingTimer = setInterval(() =>
+              this.SendMessage(new Messages.Ping(this._counter)), Math.round(ping / 2));
+          }
           res();
           break;
         case 'Error':

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -141,6 +141,9 @@ export class ButtplugClient extends EventEmitter {
             this.emit('deviceremoved', d);
           }
           break;
+        case 'ScanningFinished':
+          this.emit('scanningfinished', x);
+          break;
       };
     });
   }

--- a/src/core/messages.ts
+++ b/src/core/messages.ts
@@ -52,9 +52,20 @@ export class Test extends ButtplugMessage {
   }
 }
 
+export enum ErrorClass {
+    ERROR_UNKNOWN,
+    ERROR_INIT,
+    ERROR_PING,
+    ERROR_MSG,
+    ERROR_DEVICE
+}
+
 export class Error extends ButtplugSystemMessage {
-  constructor(public ErrorMessage: string,
-              public Id: number = 1) {
+     
+
+    constructor(public ErrorMessage: string,
+                public ErrorCode: ErrorClass = ErrorClass.ERROR_UNKNOWN,
+                public Id: number = 1) {
     super(Id);
   }
 }
@@ -102,9 +113,15 @@ export class StartScanning extends ButtplugMessage {
 }
 
 export class StopScanning extends ButtplugMessage {
-  constructor(public Id: number = 1) {
-    super(Id);
-  }
+    constructor(public Id: number = 1) {
+        super(Id);
+    }
+}
+
+export class ScanningFinished extends ButtplugSystemMessage {
+    constructor() {
+        super();
+    }
 }
 
 export class RequestLog extends ButtplugMessage {
@@ -196,6 +213,7 @@ let Messages = {
   RequestDeviceList: RequestDeviceList,
   StartScanning: StartScanning,
   StopScanning: StopScanning,
+  ScanningFinished: ScanningFinished,
   RequestLog: RequestLog,
   Log: Log,
   RequestServerInfo: RequestServerInfo,

--- a/tests/core/client.ts
+++ b/tests/core/client.ts
@@ -76,6 +76,19 @@ describe("Client Tests", async () => {
     return p;
   });
 
+  it("Should emit when device scanning is over", async () => {
+      mockServer.on('message', (jsonmsg: string) => {
+          let msg: Messages.ButtplugMessage = Messages.FromJSON(jsonmsg)[0] as Messages.ButtplugMessage;
+          delaySend(new Messages.Ok(msg.Id));
+          delaySend(new Messages.ScanningFinished());
+      });
+      bp.on('scanningfinished', (x) => {
+          res();
+      });
+      await bp.StartScanning();
+      return p;
+  });
+
   it("Should allow correct device messages and reject unauthorized", async () => {
     mockServer.on('message', (jsonmsg: string) => {
       let msg: Messages.ButtplugMessage = Messages.FromJSON(jsonmsg)[0] as Messages.ButtplugMessage;

--- a/tests/core/messages.ts
+++ b/tests/core/messages.ts
@@ -3,27 +3,30 @@ import { expect } from "chai";
 import 'mocha';
 
 describe("Message", () => {
-  it("Converts ok message to json correctly",
-    () => {
-      let ok = new Messages.Ok(2);
-      expect(ok.toJSON()).to.equal('{"Ok":{"Id":2}}');
-    });
-  it("Converts ok message from json correctly",
-    () => {
-      let json_str = '[{"Ok":{"Id":2}}]';
-      expect(Messages.FromJSON(json_str)).to.deep.equal([new Messages.Ok(2)]);
-    });
-  // it ("Converts DeviceList message from json correctly",
-  //     () => {
-  //       let json_str = '{"DeviceList":{"Id":2,"Devices": [{"DeviceIndex":0,"DeviceName":"Test","DeviceMessages":["Ok","Ping"]},{"DeviceIndex":1,"DeviceName":"Test1","DeviceMessages":["Ok","Ping"]}]}}';
-  //       console.log(Messages.FromJSON(json_str));
-  //       //expect().to.not.throw();
-  //     });
-  // it ("Converts DeviceAdded message from json correctly",
-  //     () => {
-  //       let json_str = '{"DeviceAdded":{"Id":2,"DeviceIndex":0,"DeviceName":"Test","DeviceMessages":["Ok","Ping"]}}';
-  //       console.log(Messages.FromJSON(json_str));
-  //       //expect().to.not.throw();
-  //     });
+    it("Converts ok message to json correctly",
+        () => {
+            let ok = new Messages.Ok(2);
+            expect(ok.toJSON()).to.equal('{"Ok":{"Id":2}}');
+        });
+    it("Converts ok message from json correctly",
+        () => {
+            let json_str = '[{"Ok":{"Id":2}}]';
+            expect(Messages.FromJSON(json_str)).to.deep.equal([new Messages.Ok(2)]);
+        });
+    it("Converts DeviceList message from json correctly",
+        () => {
+            let json_str = '{"DeviceList":{"Id":2,"Devices": [{"DeviceIndex":0,"DeviceName":"Test","DeviceMessages":["Ok","Ping"]},{"DeviceIndex":1,"DeviceName":"Test1","DeviceMessages":["Ok","Ping"]}]}}';
+            expect(Messages.FromJSON(json_str)).to.deep.equal([new Messages.DeviceList([new Messages.DeviceInfo(0, "Test", ["Ok", "Ping"]), new Messages.DeviceInfo(1, "Test1", ["Ok", "Ping"])], 2)]);
+        });
+    it("Converts DeviceAdded message from json correctly",
+        () => {
+            let json_str = '{"DeviceAdded":{"Id":0,"DeviceIndex":0,"DeviceName":"Test","DeviceMessages":["Ok","Ping"]}}';
+            expect(Messages.FromJSON(json_str)).to.deep.equal([new Messages.DeviceAdded(0, "Test", ["Ok", "Ping"])]);
+        });
+    it("Converts Error message from json correctly",
+        () => {
+            let json_str = '{"Error":{"Id":2,"ErrorCode":3,"ErrorMessage":"TestError"}}';
+            expect(Messages.FromJSON(json_str)).to.deep.equal([new Messages.Error("TestError", Messages.ErrorClass.ERROR_MSG, 2)]);
+        });
 });
 


### PR DESCRIPTION
Hoping to satisfy #3 by adding the ErrorCode property to the Error message (and with it the epic buttplug-20).
Also adding support for the ScanningFinished message to un-block buttplug-cspharp-83.
And now with a ping timer so that buttplug-cspharp-127 doesn't immediately close the connection on you.