### PR TITLE
fix: Make WebBluetooth manager emit scanningfinished on cancel/connect

### DIFF
--- a/src/server/bluetooth/WebBluetoothDeviceManager.ts
+++ b/src/server/bluetooth/WebBluetoothDeviceManager.ts
@@ -23,7 +23,7 @@ export default class WebBluetoothDeviceManager extends EventEmitter implements I
     (((navigator as any).bluetooth) as Bluetooth).requestDevice(filters).then(async (device) => {
       await this.OpenDevice(device);
       this.emit("scanningfinished");
-    });
+    }).catch(() => this.emit("scanningfinished"));
     return true;
   }
 


### PR DESCRIPTION
WebBluetoothManager will now emit scanningfinished when device is
either connected or requestdevice is cancelled. DeviceManager will
emit a ScanningFinished message when all managers are finished scanning.

Fixes #31